### PR TITLE
Fix linking to shared libopenvr_api.so on Linux

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -96,27 +96,10 @@
           "OS=='linux'",
           {
             "libraries": [
-              "-lopenvr_api",
-              "-L<(module_root_dir)/openvr/lib/"
+              "<(module_root_dir)/openvr/lib/libopenvr_api.so"
             ],
             "defines": [
               "LINUX"
-            ],
-            "actions": [
-              {
-                "action_name": "copy_openvr_libs",
-                "inputs": [
-                  "<(module_root_dir)/openvr/bin/libopenvr_api.so"
-                ],
-                "outputs": [
-                  "<(module_root_dir)/build/Release/libopenvr_api.so"
-                ],
-                "action": [
-                  "cp",
-                  "<@(_inputs)",
-                  "<@(_outputs)"
-                ]
-              }
             ]
           }
         ]


### PR DESCRIPTION
As promised! :)

This fixed the library loading issue. I haven't done any deeper testing on Linux yet, will do so once this is available through the package manager!