### PR TITLE
Fix TypeScript typing for TrackedDevicePose_t

### DIFF
--- a/tssrc/index.ts
+++ b/tssrc/index.ts
@@ -94,13 +94,12 @@ export const IsRoleAllowedAsHand = function (eRole: ETrackedControllerRole): boo
     }
 }
 export type TrackedDevicePose_t = {
-    mDeviceToAbsoluteTracking: HmdMatrix34_t;
-    vVelocity: HmdVector3_t;
-    VAngularVelocity: HmdVector3_t;
-    eTrackingResult: ETrackingResult;
-    bPoseIsValid: boolean;
-
-    bDeviceIsConnected: boolean;
+    deviceToAbsoluteTracking: HmdMatrix34_t;
+    velocity: HmdVector3_t;
+    angularVelocity: HmdVector3_t;
+    trackingResult: ETrackingResult;
+    poseIsValid: boolean;
+    deviceIsConnected: boolean;
 }
 export enum ETrackingUniverseOrigin {
     TrackingUniverseSeated = 0,


### PR DESCRIPTION
The TypeScript type for TrackedDevicePose_t was incorrectly prefixing all properties with their type. This correction is based on `console.log()` output of the `GetDeviceToAbsoluteTrackingPose()` method call.