### PR TITLE
Add rudimentary IVRApplications support

### DIFF
--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -1,5 +1,6 @@
 #include "ivrsystem.h"
 #include "ivroverlay.h"
+#include "ivrapplications.h"
 #include "openvr.h"
 
 #include <nan.h>
@@ -8,7 +9,7 @@ void Initialize(v8::Local<v8::Object> exports)
 {
     v8::Local<v8::Context> context = exports->CreationContext();
 
-    exports->Set(context, 
+    exports->Set(context,
                  Nan::New("VR_Init").ToLocalChecked(),
                  Nan::New<v8::FunctionTemplate>(VR_Init)->GetFunction(context).ToLocalChecked());
     exports->Set(context,
@@ -32,12 +33,16 @@ void Initialize(v8::Local<v8::Object> exports)
     exports->Set(context,
                  Nan::New("VR_GetInitToken").ToLocalChecked(),
                  Nan::New<v8::FunctionTemplate>(VR_GetInitToken)->GetFunction(context).ToLocalChecked());
-     exports->Set(context,
+    exports->Set(context,
                  Nan::New("IVROverlay_Init").ToLocalChecked(),
                  Nan::New<v8::FunctionTemplate>(IVROverlay_Init)->GetFunction(context).ToLocalChecked());
-                 
+    exports->Set(context,
+                 Nan::New("IVRApplications_Init").ToLocalChecked(),
+                 Nan::New<v8::FunctionTemplate>(IVRApplications_Init)->GetFunction(context).ToLocalChecked());
+
     IVRSystem::Init(exports);
     IVROverlay::Init(exports);
+    IVRApplications::Init(exports);
 }
 
 NODE_MODULE(openvr, Initialize);

--- a/src/ivrapplications.cpp
+++ b/src/ivrapplications.cpp
@@ -1,0 +1,105 @@
+#include "ivrapplications.h"
+#include "util.h"
+
+#include <array>
+#include <node.h>
+#include <openvr.h>
+
+void IVRApplications::Init(Local<Object> exports)
+{
+    Local<Context> context = exports->CreationContext();
+    Nan::HandleScope scope;
+
+    Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
+    tpl->SetClassName(Nan::New("IVRApplications").ToLocalChecked());
+    tpl->InstanceTemplate()->SetInternalFieldCount(1);
+
+    Nan::SetPrototypeMethod(tpl, "AddApplicationManifest", AddApplicationManifest);
+    Nan::SetPrototypeMethod(tpl, "RemoveApplicationManifest", RemoveApplicationManifest);
+    Nan::SetPrototypeMethod(tpl, "IsApplicationInstalled", IsApplicationInstalled);
+
+    constructor.Reset(tpl->GetFunction(context).ToLocalChecked());
+    exports->Set(
+        context,
+        Nan::New("IVRApplications").ToLocalChecked(),
+        tpl->GetFunction(context).ToLocalChecked());
+}
+
+Local<Object> IVRApplications::NewInstance(vr::IVRApplications *applications)
+{
+    Nan::EscapableHandleScope scope;
+    Local<Function> cons = Nan::New(constructor);
+    Local<Value> argv[1] = {Nan::New<External>(system)};
+    return scope.Escape(Nan::NewInstance(cons, 1, argv).ToLocalChecked());
+}
+
+IVRApplications::IVRApplications(vr::IVRApplications *self)
+    : self_(self)
+{
+}
+
+void IVRApplications::New(const Nan::FunctionCallbackInfo<Value> &info)
+{
+    if (!info.IsConstructCall())
+    {
+        Nan::ThrowError("Use the `new` keyword when creating a new instance.");
+        return;
+    }
+
+    auto wrapped_instance = static_cast<vr::IVRApplications *>(
+        Local<External>::Cast(info[0])->Value());
+    IVRApplications *obj = new IVRApplications(wrapped_instance);
+    obj->Wrap(info.This());
+    info.GetReturnValue().Set(info.This());
+}
+
+// ------------------------------------
+// Application management
+// ------------------------------------
+
+// virtual EVRApplicationError AddApplicationManifest( const char *pchApplicationManifestFullPath, bool bTemporary = false )
+void IVRApplications::AddApplicationManifest(const Nan::FunctionCallbackInfo<Value> &info)
+{
+    Local<Context> context = info.GetIsolate()->GetCurrentContext();
+    IVRApplications *obj = Nan::ObjectWrap::Unwrap<IVRApplications>(info.Holder());
+
+    const char *pchApplicationManifestFullPath = *(Nan::Utf8String(info[0]));
+    bool bTemporary = info[1]->BooleanValue(info.GetIsolate());
+
+    vr::EVRApplicationError error = obj->self_->AddApplicationManifest(pchApplicationManifestFullPath, bTemporary);
+
+    if (error != vr::EVRApplicationError_None)
+    {
+        Nan::ThrowError(obj->self_->GetApplicationsErrorNameFromEnum(error));
+        return;
+    }
+}
+
+// virtual EVRApplicationError RemoveApplicationManifest( const char *pchApplicationManifestFullPath )
+void IVRApplications::RemoveApplicationManifest(const Nan::FunctionCallbackInfo<Value> &info)
+{
+    Local<Context> context = info.GetIsolate()->GetCurrentContext();
+    IVRApplications *obj = Nan::ObjectWrap::Unwrap<IVRApplications>(info.Holder());
+
+    const char *pchApplicationManifestFullPath = *(Nan::Utf8String(info[0]));
+
+    vr::EVRApplicationError error = obj->self_->RemoveApplicationManifest(pchApplicationManifestFullPath);
+
+    if (error != vr::EVRApplicationError_None)
+    {
+        Nan::ThrowError(obj->self_->GetApplicationsErrorNameFromEnum(error));
+        return;
+    }
+}
+
+// virtual bool IsApplicationInstalled( const char *pchAppKey )
+void IVRApplications::IsApplicationInstalled(const Nan::FunctionCallbackInfo<Value> &info)
+{
+    Local<Context> context = info.GetIsolate()->GetCurrentContext();
+    IVRApplications *obj = Nan::ObjectWrap::Unwrap<IVRApplications>(info.Holder());
+
+    const char *pchAppKey = *(Nan::Utf8String(info[0]));
+
+    bool isApplicationInstalled = obj->self_->IsApplicationInstalled(pchAppKey);
+    info.GetReturnValue().Set(Nan::New<Boolean>(isApplicationInstalled));
+}

--- a/src/openvr.cpp
+++ b/src/openvr.cpp
@@ -1,6 +1,7 @@
 #include "openvr.h"
 #include "ivrsystem.h"
 #include "ivroverlay.h"
+#include "ivrapplications.h"
 
 #include <node.h>
 #include <openvr.h>
@@ -90,5 +91,11 @@ void VR_GetInitToken(const Nan::FunctionCallbackInfo<Value> &info)
 void IVROverlay_Init(const Nan::FunctionCallbackInfo<Value>& info)
 {
     auto result = IVROverlay::NewInstance(vr::VROverlay());
+    info.GetReturnValue().Set(result);
+}
+
+void IVRApplications_Init(const Nan::FunctionCallbackInfo<Value>& info)
+{
+    auto result = IVRApplications::NewInstance(vr::VRApplications());
     info.GetReturnValue().Set(result);
 }

--- a/src/openvr.h
+++ b/src/openvr.h
@@ -38,4 +38,6 @@ void VR_GetInitToken(const Nan::FunctionCallbackInfo<Value>& info);
 
 void IVROverlay_Init(const Nan::FunctionCallbackInfo<Value>& info);
 
+void IVRApplications_Init(const Nan::FunctionCallbackInfo<Value>& info);
+
 #endif

--- a/tssrc/index.ts
+++ b/tssrc/index.ts
@@ -1404,6 +1404,7 @@ export const VR_GetVRInitErrorAsEnglishDescription = function (error: EVRInitErr
 export const VR_GetInitToken = function (): number { return openvr.VR_GetInitToken(); }
 
 export const IVROverlay_Init = function (): IVROverlay { return openvr.IVROverlay_Init(); }
+export const IVRApplications_Init = function (): IVRApplications { return openvr.IVRApplications_Init(); }
 
 
 export class IVRSystem {
@@ -1744,4 +1745,23 @@ export class IVROverlay {
         else openvr.IVROverlay.ShowMessageOverlay(Text, Caption, Button0Text, Button1Text, Button2Text, Button3Text);
     }
     CloseMessageOverlay() { openvr.IVROverlay.CloseMessageOverlay(); }
+}
+
+export class IVRApplications {
+
+    // ---------------------------------------------
+    // Application management
+    // ---------------------------------------------
+
+    AddApplicationManifest(applicationManifestFullPath : string, temporary = false) : void {
+        openvr.IVRApplications.AddApplicationManifest(applicationManifestFullPath, temporary);
+    }
+
+    RemoveApplicationManifest(applicationManifestFullPath : string) : void {
+        openvr.IVRApplications.RemoveApplicationManifest(applicationManifestFullPath);
+    }
+
+    IsApplicationInstalled(appKey : string) : boolean {
+        return openvr.IVRApplications.IsApplicationInstalled(appKey);
+    }
 }


### PR DESCRIPTION
This is my initial stab to get a few methods from `IVRApplications` in, specifically:

- `AddApplicationManifest`
- `RemoveApplicationManifest`
- `IsApplicationInstalled`

This is all based on how `IVROverlay` was implemented and I verified that it builds without issues. Eventually, more of the `IVRApplications` methods could be added, but these are the most pressing ones to get an application registered so it can autostart with SteamVR.